### PR TITLE
Info about proxies and agents

### DIFF
--- a/installation/configure_proxy.md
+++ b/installation/configure_proxy.md
@@ -36,6 +36,12 @@ RequestHeader set X_FORWARDED_PROTO 'https'
 
 This directive can replace HTTP request headers. The header is modified just before the content handler is run, allowing incoming headers to be changed to 'https'.
 
+## Agents and custom SSL ports
+
+Keep in mind that the agents must still be able to connect to the SSL port of the server (8154 by default), bypassing the proxy. The Go server itself needs to terminate the TLS connections of the agents, because they each use TLS client certificates to authenticate themselves to the server. So you have a firewall between your agents and your server, you must allow incoming traffic on the Go server SSL port, not just on the proxy server SSL port.
+
+The initial communication of the agent to the server happens over HTTP, and this can go via the proxy, but afterwards all traffic will go directly via a TLS connection to the Go server (in fact, configuring the agent with the the SSL port instead of the HTTP port of the server will give an error for this initial connection).
+
 ## Also see...
 
 -   [Configure site URLs](../installation/configuring_server_details.md#configure-site-urls)

--- a/installation/configure_proxy.md
+++ b/installation/configure_proxy.md
@@ -36,6 +36,7 @@ RequestHeader set X_FORWARDED_PROTO 'https'
 
 This directive can replace HTTP request headers. The header is modified just before the content handler is run, allowing incoming headers to be changed to 'https'.
 
+<a name="agents-and-custom-ssl-ports"></a>
 ## Agents and custom SSL ports
 
 Keep in mind that the agents must still be able to connect to the SSL port of the server (8154 by default), bypassing the proxy. The Go server itself needs to terminate the TLS connections of the agents, because they each use TLS client certificates to authenticate themselves to the server. So you have a firewall between your agents and your server, you must allow incoming traffic on the Go server SSL port, not just on the proxy server SSL port.

--- a/installation/install/agent/osx.md
+++ b/installation/install/agent/osx.md
@@ -38,4 +38,8 @@ The GoCD agent installs its files in the following locations on your filesystem:
 
 Some logging information is also written to ```/var/log/system.log```
 
+## Setting the server location without the GUI
+
+You can specify the server location in the GUI, but you can also modify the properties file itself (when the Go agent app is not running). This allows you to set a custom port number, which is not possible in the GUI ([be aware that this might not always work as you expect](../../configure_proxy.md#agents-and-custom-ssl-ports)). The properties file is located in `~/Library/Preferences/com.thoughtworks.studios.cruise.agent.properties`, and has a `port` and a `server` property.
+
 !INCLUDE "_register_with_server.md"


### PR DESCRIPTION
Clearly explain how adding a proxy will still require access to the SSL server port for agents.

Also document how the port can be set for the Mac agent, but add a warning because you probably don't want to do this.

The Linux page already refers to the `/etc/default/go-agent` file, which contains the `GO_SERVER_PORT` key, so extra info is probably not necessary there.

Based on gocd/gocd#2032 and gocd/gocd#1459.