### PR TITLE
Add guide for custom x509 certs to SSL/TLS section

### DIFF
--- a/installation/ssl_tls_config.md
+++ b/installation/ssl_tls_config.md
@@ -6,7 +6,7 @@ You can choose which ciphers and SSL/TLS protocols Go will use for communication
 
 **NOTE:** These settings will not apply if you are running Go with Jetty 6.
 
-Following system properties are exposed to override the default SSL/TLS configuration for Go server: 
+Following system properties are exposed to override the default SSL/TLS configuration for Go server:
 
 
 |*Key*                          |*Default value*|*Description*                |
@@ -18,17 +18,17 @@ Following system properties are exposed to override the default SSL/TLS configur
 |`go.ssl.renegotiation.allowed` |Y       |Flag to allow/dis-allow TLS renegotiation, accepts - `Y` and `N`|
 
 ### Setting it up:
-	
+
 * Linux
 
 	This can be configured through `/etc/default/go-server`, such as:
-	
+
 	``` shell
 export GO_SERVER_SYSTEM_PROPERTIES="-Dgo.ssl.ciphers.include='TLS_ECDHE.*' -Dgo.ssl.ciphers.exclude='.*NULL.*,.*RC4.*' -Dgo.ssl.protocols.include='TLSv1.2' -Dgo.ssl.protocols.exclude='SSLv3' -Dgo.ssl.renegotiation.allowed='N'"
 ```
 
 * Windows
-    
+
     Follow the [instructions](./install/server/windows.html#overriding-default-startup-arguments-and-environment) to add a new property for Go server setup on windows, such as:
 
     ``` shell
@@ -43,13 +43,13 @@ The default transport protocol that agent uses to communicate with Go server is 
 * Linux
 
 	This can be configured through `/etc/default/go-agent`, such as:
-	
+
 	``` shell
 export GO_AGENT_SYSTEM_PROPERTIES="-Dgo.ssl.agent.protocol='SSL'"
 ```
 
 * Windows
-    
+
     Follow the [instructions](./install/agent/windows.html#overriding-default-startup-arguments-and-environment) to add a new property for Go agents setup on windows, such as:
 
     ``` shell
@@ -58,3 +58,34 @@ wrapper.java.additional.17="-Dgo.ssl.agent.protocol='SSL'"
 	Restart agent for the changes to take effect.
 
 Read [jetty's documentation](http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html) to know more about SSL/TLS configuration.
+
+## Using Custom Certificates
+
+To use your own custom x509 certificates for SSL/TLS connections between the Go Server and Go Agent instead of gocd's default self-signed certificates, do the following:
+
+### Configure Go Server:
+
+Add your private key and x509 certificate to the go-server's keystore [following this guide](https://www.go.cd/2014/06/05/using-go-cd-with-custom-certificates.html).
+
+### Configure Go Agent:
+
+1. Use [scp](http://www.hypexr.org/linux_scp_help.php) (or your preferred transport layer) to upload your x509 certificate to your home directory. For example:
+
+  ```shell
+  $ scp your-certificate.crt your-username@your-go-agent-hostname.net:/home/your-username/tmp/
+  ```
+
+2. Add the certificate to the go-agent's keystore, located at `var/lib/go-agent/config/trust.jks`. For example:
+
+  ```shell
+  $ cd /var/libe/go-agent/config
+  $ keytool -import -alias your-certificate-name -file /home/your-username/tmp -keystore trust.jks
+  ```
+
+3. You will be prompted for the password for the go-agent keystore, which is:
+
+  ```shell
+  agent5s0repa55w0rd
+  ```
+
+4. Restart the Go Agent with `sudo service go-agent restart` to establish a fresh connection to the Go Server.


### PR DESCRIPTION
* __As a__ security-concious maintainer of a site with custom x509 certs
* __I Want__ to use my own custom x509 certificate on my Go
Server
* __So That__ team members can reach the gocd dashboard at a secure, user-friendly URL like `https://go.mydomain.com`
* __And__ browsers will not warn users about insecure connections when
they try to use gocd's default self-signed certs

__But__: documentation on how to meet this use case is missing from the docs, and configuring the server alone as described [here](https://www.go.cd/2014/06/05/using-go-cd-with-custom-certificates.html) causes the Go Agent to fail when trying to connect to the server, because the Go Agent trust store doesn't contain the custom cert.

This PR adds documentation on how to add custom x509 certs to both the Go Server and Go Agent.