### PR TITLE
Fix typo in PR #17

### DIFF
--- a/installation/ssl_tls_config.md
+++ b/installation/ssl_tls_config.md
@@ -79,7 +79,10 @@ Add your private key and x509 certificate to the go-server's keystore [following
 
   ```shell
   $ cd /var/libe/go-agent/config
-  $ keytool -import -alias your-certificate-name -file /home/your-username/tmp -keystore trust.jks
+  $ keytool -import \
+    -alias your-certificate-name \
+    -file /home/your-username/tmp/your-certificate.crt \
+    -keystore trust.jks
   ```
 
 3. You will be prompted for the password for the go-agent keystore, which is:


### PR DESCRIPTION
The example bash code in pull request #17 omits the filename for the cert being inserted into the go-agent trust store.

This PR fixes that typo and provides arguments on separate lines for better readability.