### PR TITLE
Updated windows SSL configuration

### DIFF
--- a/installation/install/agent/windows.md
+++ b/installation/install/agent/windows.md
@@ -51,6 +51,16 @@ C:\> go-agent-16.1.0-1234-setup.exe /S /SERVERIP=10.12.20.47 /D=C:\go\agent
     # since the last "wrapper.java.additional" index is 2, we use the next available index.
     wrapper.java.additional.3=-Xmx512mb
     ```
+-   Each property must be configured separately
+
+    ```
+    # Having a single property for multiple configurations is invalid, e.g
+    wrapper.java.additional.16="-Dcruise.config.foo='bar' -Dcruise.config.other='baz'"
+
+    Valid properties,
+    wrapper.java.additional.16=-Dcruise.config.foo=bar
+    wrapper.java.additional.17=-Dcruise.config.other=baz
+    ```
 
 ## Location of GoCD agent files
 

--- a/installation/install/server/windows.md
+++ b/installation/install/server/windows.md
@@ -49,6 +49,16 @@ C:\> go-server-16.1.0-1234-setup.exe /S /D=C:\go\server
     # since the last "wrapper.java.additional" index is 15, we use the next available index.
     wrapper.java.additional.16=-Dcruise.config.foo=bar
     ```
+-   Each property must be configured separately
+
+    ```
+    # Having a single property for multiple configurations is invalid, e.g
+    wrapper.java.additional.16="-Dcruise.config.foo='bar' -Dcruise.config.other='baz'"
+
+    Valid properties,
+    wrapper.java.additional.16=-Dcruise.config.foo=bar
+    wrapper.java.additional.17=-Dcruise.config.other=baz
+    ```
 
 ## Location of GoCD server files
 

--- a/installation/ssl_tls_config.md
+++ b/installation/ssl_tls_config.md
@@ -4,8 +4,6 @@ You can choose which ciphers and SSL/TLS protocols Go will use for communication
 
 ## Configuring Go server
 
-**NOTE:** These settings will not apply if you are running Go with Jetty 6.
-
 Following system properties are exposed to override the default SSL/TLS configuration for Go server:
 
 
@@ -32,7 +30,11 @@ export GO_SERVER_SYSTEM_PROPERTIES="-Dgo.ssl.ciphers.include='TLS_ECDHE.*' -Dgo.
     Follow the [instructions](./install/server/windows.html#overriding-default-startup-arguments-and-environment) to add a new property for Go server setup on windows, such as:
 
     ``` shell
-wrapper.java.additional.17="-Dgo.ssl.ciphers.include='TLS_ECDHE.*' -Dgo.ssl.ciphers.exclude='.*NULL.*,.*RC4.*' -Dgo.ssl.protocols.include='TLSv1.2' -Dgo.ssl.protocols.exclude='SSLv3' -Dgo.ssl.renegotiation.allowed='N'"
+wrapper.java.additional.17="-Dgo.ssl.ciphers.include='TLS_ECDHE.*'"
+wrapper.java.additional.18="-Dgo.ssl.ciphers.exclude='.*NULL.*,.*RC4.*'"
+wrapper.java.additional.19="-Dgo.ssl.protocols.include='TLSv1.2'"
+wrapper.java.additional.20="-Dgo.ssl.protocols.excludE='SSLv3'"
+wrapper.java.additional.21="-Dgo.ssl.renegotiation.allowed='N'"
 ```
 	Restart server for the changes to take effect.
 


### PR DESCRIPTION
SSL Configuration as a single property does not work on windows,
each ssl property has to be specified separately