### PR TITLE
Config repos user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ npm install
 ### Serve the documentation locally
 
 ```
-$ gitbook install
-$ gitbook serve
+$ npm run init-gitbook
+$ npm run serve
 ```
 
 Point your browser to [http://localhost:4000/](http://localhost:4000/)
@@ -23,7 +23,7 @@ Point your browser to [http://localhost:4000/](http://localhost:4000/)
 ### Generating the static website
 
 ```
-$ gitbook build [path_to_repository]
+$ npm run build
 ```
 
 ### Generating the documentation in other formats

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -115,6 +115,7 @@ This is the summary of user documentation.
     * [SCM Extension](extension_points/scm_extension.md)
     * [Task Extension](extension_points/task_extension.md)
     * [Notification Extension](extension_points/notification_extension.html)
+    * [Configuration repository Extension](extension_points/configrepo_extension.md)
 * [FAQ/Troubleshooting](faq/index.md)
     * [Ordering of Pipelines](faq/ordering_of_pipelines.md)
     * [Historical Configuration](faq/stage_old_config.md)

--- a/configuration/configuration_reference.md
+++ b/configuration/configuration_reference.md
@@ -46,6 +46,43 @@
         <a href="#repository">&lt;/repository&gt;</a>
     <a href="#repositories">&lt;/repositories&gt;</a>
 
+    <a href="#config-repos">&lt;config-repos&gt;</a>
+      <a href="#config-repo">&lt;config-repo&gt;</a>
+        <a href="#svn">&lt;svn&gt;</a>
+            <a href="#filter">&lt;filter&gt;</a>
+                <a href="#ignore">&lt;ignore/&gt;</a>
+            <a href="#filter">&lt;/filter&gt;</a>
+        <a href="#svn">&lt;/svn&gt;</a>
+        <a href="#hg">&lt;hg&gt;</a>
+            <a href="#filter">&lt;filter&gt;</a>
+                <a href="#ignore">&lt;ignore/&gt;</a>
+            <a href="#filter">&lt;/filter&gt;</a>
+        <a href="#hg">&lt;/hg&gt;</a>
+        <a href="#p4">&lt;p4&gt;</a>
+            &lt;view/&gt;
+            <a href="#filter">&lt;filter&gt;</a>
+                <a href="#ignore">&lt;ignore/&gt;</a>
+            <a href="#filter">&lt;/filter&gt;</a>
+        <a href="#p4">&lt;/p4&gt;</a>
+        <a href="#git">&lt;git&gt;</a>
+            <a href="#filter">&lt;filter&gt;</a>
+                <a href="#ignore">&lt;ignore/&gt;</a>
+            <a href="#filter">&lt;/filter&gt;</a>
+        <a href="#git">&lt;/git&gt;</a>
+        <a href="#tfs">&lt;tfs&gt;</a>
+            <a href="#filter">&lt;filter&gt;</a>
+                <a href="#ignore">&lt;ignore/&gt;</a>
+            <a href="#filter">&lt;/filter&gt;</a>
+        <a href="#tfs">&lt;/tfs&gt;</a>
+        <a href="#config-repo-configuration">&lt;configuration&gt;</a>
+            <a href="#config-repo-property">&lt;property&gt;</a>
+                <a href="#config-repo-property-key">&lt;key/&gt;</a>
+                <a href="#config-repo-property-value">&lt;value/&gt;</a>
+            <a href="#config-repo-property">&lt;/property&gt;</a>
+        <a href="#config-repo-configuration">&lt;/configuration&gt;</a>
+      <a href="#config-repo">&lt;/config-repo&gt;</a>
+    <a href="#config-repos">&lt;/config-repos&gt;</a>
+
     <a href="#pipelines">&lt;pipelines&gt;</a>
         <a href="#group_authorization">&lt;authorization&gt;</a>
             <a href="#group_admins">&lt;admins&gt;</a>
@@ -343,7 +380,7 @@ The `<ldap>` element is used to specify the ldap server. Users can access Go wit
 
 ## &lt;bases&gt; {#bases}
 
-The `<bases>` element is used to specify a list of search bases (the distinguished name of the search base object) which defines 
+The `<bases>` element is used to specify a list of search bases (the distinguished name of the search base object) which defines
 the location in the directory from which the LDAP search begins.
 
 [top](#top)
@@ -351,7 +388,7 @@ the location in the directory from which the LDAP search begins.
 
 ## &lt;base&gt; {#base}
 
-The `<base>` element is used to specify a search base (the distinguished name of the search base object) defines the location in 
+The `<base>` element is used to specify a search base (the distinguished name of the search base object) defines the location in
 the directory from which the LDAP search begins.
 
 | Attribute | Required | Description |
@@ -560,6 +597,85 @@ Two users would be administrators, they are **Jez** and **lqiao**.
    <user>lqiao<user>
    <role>_readonly_member<role>
 </view>
+```
+
+
+## &lt;config-repos&gt; {#config-repos}
+
+The `<config-repos>` element is a container of many `<config-repo>`.
+
+### Example
+
+```xml
+<cruise>
+  ...
+  <config-repos>
+    <config-repo plugin="json.config.plugin">
+      <git url="https://github.com/tomzo/gocd-json-config-example.git" />
+    </config-repo>
+    <config-repo plugin="yaml.config.plugin">
+      <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
+      <configuration>
+        <property>
+          <key>file_pattern</key>
+          <value>**/*.gocd.yaml</value>
+        </property>
+      </configuration>
+    </config-repo>
+  </config-repos>
+</cruise>
+```
+
+[top](#top)
+
+## &lt;config-repo&gt; {#config-repo}
+
+The `<config-repo>` element specifies a single configuration repository. It must contain exactly one SCM material and may contain additional configuration section.
+
+### Attributes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| plugin | Yes | The ID of configuration repository plugin. E.g. `json.config.plugin`. |
+
+### Example
+
+```xml
+<cruise>
+    ...
+    <config-repos>
+      <config-repo plugin="yaml.config.plugin">
+        <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
+        <configuration>
+          <property>
+            <key>file_pattern</key>
+            <value>**/*.gocd.yaml</value>
+          </property>
+        </configuration>
+      </config-repo>
+  </config-repos>
+</cruise>
+```
+
+### &lt;configuration&gt; {#config-repo-configuration}
+
+The `<configuration>` element is optional part of config repo definition.
+Keys and values are specified and handled by particular plugin. This section
+can be used to **customize how config repo plugin works when parsing this specific repository**.
+
+#### Example
+
+```xml
+<configuration>
+  <property>
+    <key>file_pattern</key>
+    <value>*.go.yaml</value>
+  </property>
+  <property>
+    <key>allowed_pipelines_regex</key>
+    <value>project-X-.*</value>
+  </property>
+</configuration>
 ```
 
 [top](#top)

--- a/extension_points/configrepo_extension.md
+++ b/extension_points/configrepo_extension.md
@@ -1,0 +1,84 @@
+# Configuration repository Extension
+
+GoCD supports writing configuration plugins starting `16.7`.
+
+It is a feature which allows you to move pipeline configurations out of GoCD and its cruise-config.xml file into one or more source-control repositories (e.g. git), so that you can modify them externally. Such modifications will be seen by a periodic poller in the GoCD server and it will [merge](#merging-configurations) those pipeline configurations into the pipelines it finds in the main configuration XML file.
+
+Configuration plugins allow users to keep both **pipeline and environment** configurations
+in all version control systems supported by Go.
+Most elements of **pipelines and environments** available in XML are supported by configuration repositories.
+However there are a few exceptions, you cannot use in configuration repositories:
+ * [GoCD pipeline templates](../pipeline_templates.md), nor references to templates. *Note that you can write a plugin that supports pipeline templates in any way you want*
+ * parameters
+
+The format in which configurations are stored is fully controlled by the plugin,
+so pipelines and environments can be stored for example in JSON, YAML, XML, dot files or any convention that can store necessary information.
+
+There are certain limits involved when using configuration repository:
+
+ - It is not possible to edit remote pipeline or environment using UI
+ - Elements defined via UI cannot refer to external ones. The other way around is possible.
+ - Pipeline templates and parameters are not supported
+
+## Merging configurations
+
+Go server polls all materials from pipelines and user-defined configuration repositories.
+The final server configuration is merged from `cruise-config.xml` and remote elements in repositories.
+It is important to pay attention to errors introduced in repositories.
+It is **highly recommended** to remove any errors as soon as Go reports them. For configuration repositories the only way to so is by pushing changes to faulty repository.
+All configuration errors are displayed in server health messages.
+More details about handling configuration repository errors in Go server are [lower](#errors-in-configuration-repository).
+
+### Merging pipeline groups
+
+Pipeline's membership in a group can be defined in many configuration repositories and `cruise-config.xml`.
+E.g. group `project1` can be spread across many configuration repositories,
+ then finally in Go server all these pipelines will show up in one group `project1`.
+
+### Merging environments
+
+Similarly to pipeline groups, final members of environments are a sum of elements in
+all configuration repositories. E.g.
+ - in repository A we can define that `pipeline1` is member of environment `development`
+ - in repository B we can define that `pipeline2` and `pipeline3` is member of environment `development`
+ - in repository C we can define that `pipeline3` is member of environment `development`
+
+Then in Go server, the final pipelines in environment `development` are `pipeline1`, `pipeline2`, `pipeline3`.
+Notice that `pipeline3` membership in environment `development` was declared twice.
+
+Same approach is used for agents.
+
+Environment variables have an additional check. If you assign same environment variable
+with 2 different values then it is considered configuration merge conflict.
+
+### Errors in configuration repository
+
+There are several ways in which current configuration can be invalid because of errors in configuration repository.
+
+#### Configuration repository plugin Error
+The least problematic situation is when plugin or extension point has detected problems with remote configuration part *alone*.
+Then Go does not attempt to merge this configuration repository and previous configuration part stays *active*. You should fix errors reported by Go server health messages in order to see any new changes from that configuration repository.
+If you don't fix such error, there are no other consequences than having old configuration.
+Many errors of this type can exist simultaneously - there can be many invalid repositories in *this way*.
+
+#### Invalid Merged Configuration Error
+
+In some situations it is not possible to create merged configuration from configuration repositories
+and main Go configuration. Then server health messages reports **Invalid Merged Configuration**.
+
+The common cases that will cause this error are:
+ - a pipeline is configured both through UI (in `cruise-config.xml`) and in on of configuration repositories.
+ - pipelines with same name are declared in many configuration repositories.
+ - one of the pipelines refers to non-existing pipeline. Or more generally some configuration element refers to other that does not exist.
+ - plugin or extension point is not doing enough validations on the remote configuration part *alone*. This causes server to assemble merged configuration from part which is invalid.
+
+There are **limitations** in how Go server can handle this type of error(s):
+1. Go can handle situation when there are errors in **exactly one** of the repositories. You will not see new configuration changes from invalid repository until error is fixed. Other configuration repositories and edits to Config XML will be operational. You should fix **Invalid Merged Configuration** anyway to avoid being in next situation...
+2. When **2 or more** configuration repositories are invalid - you *may* start experiencing being *locked out* from editing configuration through UI. Changes to XML will be rejected. Reasons for this are beyond scope of this document. You **must fix all configuration repositories first**.
+
+## References
+
+* [Introduction to configuration repositories](https://docs.google.com/document/d/1_eGZaqIz9ydnYQJ_Xrcb3obXc-T6jIfV_pgZQNCydVk/edit?pref=2&pli=1)
+* [Github issue](https://github.com/gocd/gocd/issues/1133) including very long debate on how Go should behave
+* [Example configuration repository in JSON](https://github.com/tomzo/gocd-json-config-example)
+* [Example configuration repository in YAML](https://github.com/tomzo/gocd-yaml-config-example)

--- a/extension_points/index.md
+++ b/extension_points/index.md
@@ -22,6 +22,10 @@ See [this](task_extension.md) for details about the task extension point. Go doe
 
 See [this](https://plugin-api.go.cd/current/notifications) for details about the notification extension point. Go does not have a bundled notification extension. You can see [Email notification extension](https://github.com/srinivasupadhya/email-notifier) for reference.
 
+# Configuration repository Extension
+
+See [this](configrepo_extension.md) for details about the configuration repository extension point. You can see [JSON config plugin](https://github.com/tomzo/gocd-json-config-example) for reference.
+
 # Note
 
 - You can find more extensions in the community [plugins listing page](http://www.go.cd/community/plugins.html).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "init-gitbook": "gitbook install",
+    "serve": "gitbook serve",
     "build": "gitbook build .",
     "minify": "grunt"
   },


### PR DESCRIPTION
 * XML reference of the `<config-repos>` section with some examples
 * user docs about config-repos extension point, including:
  * overview of feature
  * scope of what can be defined in remote pipelines
  * what merging behavior is expected for groups and environments
  * errors and limitations