### PR TITLE
Update silent Windows agent install instructions with the new /SERVER…

### DIFF
--- a/installation/install/agent/windows.md
+++ b/installation/install/agent/windows.md
@@ -18,18 +18,18 @@ You must be logged in as a user with Admin privileges to install the GoCD agent 
 You may use this method if you would like to script the installation of the GoCD agent.
 
 ```
-go-agent-${version}-setup.exe /S /SERVERIP=<SERVERIP> /GO_AGENT_JAVA_HOME=<PATH_TO_JAVA_HOME> /D=<PATH_TO_AGENT_DIRECTORY>
+go-agent-${version}-setup.exe /S /SERVERURL="<SERVERURL>" /GO_AGENT_JAVA_HOME=<PATH_TO_JAVA_HOME> /D=<PATH_TO_AGENT_DIRECTORY>
 ```
 
 |Argument                       |Required|Description                                                                                                                         |
 |-------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------|
-|`SERVERIP`                 | No     | The hostname of the GoCD server. Defaults to `127.0.0.1`.                                                                        |
+|`SERVERURL`                | No     | The URL of the GoCD server. Defaults to `https://127.0.0.1:8154/go`. The value must be surrounded by `"` quotes.                       |
 |`GO_AGENT_JAVA_HOME`       | No     | The path to a JRE (or JDK) that the agent should run with. Defaults to the jre packaged with the agent. Needs to be at-least Java 7.|
 |`PATH_TO_AGENT_DIRECTORY`  | No     | The path where the agent should be installed. Defaults to `C:\Program Files(x86)\Go Agent`.                                    |
 
 For example:
 ```
-C:\> go-agent-16.1.0-1234-setup.exe /S /SERVERIP=10.12.20.47 /D=C:\go\agent
+C:\> go-agent-16.1.0-1234-setup.exe /S /SERVERURL="https://10.12.20.47:8154/go" /D=C:\go\agent
 ```
 
 !INCLUDE "../_install_windows_headless_message.md"


### PR DESCRIPTION
…URL option, which replaces /SERVERIP

The installer script changed in gocd/gocd@69385a057439d0f1babb24fa3aa94a0381165582

The need for `"` quotes was found by trial and error: When I ran `go-agent-16.7.0-3819-setup.exe /S /SERVERURL=https://10.12.20.47:8154/go`, the `GO_SERVER_URL` environment variable became set to just `https:`.