### PR TITLE
Update admin_install_multiple_agents.md

### DIFF
--- a/advanced_usage/admin_install_multiple_agents.md
+++ b/advanced_usage/admin_install_multiple_agents.md
@@ -89,5 +89,5 @@ sc create GoAgent2 binPath= "\"C:\Program Files\Go Agent2\cruisewrapper.exe\" -s
 -   Make an empty folder called /var/lib/go-agent-2
 -   In this folder, run
 ```
-java -jar /usr/share/go-agent/agent-bootstrapper.jar 127.0.0.1 &
+java -jar /usr/share/go-agent/agent-bootstrapper.jar -serverUrl https://127.0.0.1/go &
 ```


### PR DESCRIPTION
agent-bootstrap.jar requires that the url begins with https:// and ends with /go.
Not specifying this will output the following error:
-serverUrl is not a valid url

Docs from the jar:
Usage: java -jar agent-bootstrapper.jar [options]
  Options:
    -help
       Print this help
       Default: false
    -rootCertFile
       The root certificate from the certificate chain of the GoCD server (in
       PEM format)
  * -serverUrl
       The GoCD server URL. Must begin with `https://`, and end with `/go`
    -sslVerificationMode
       The SSL verification mode.
       Default: NONE
       Possible Values: [FULL, NONE, NO_VERIFY_HOST]