### PR TITLE
Troubleshooting guide for java 7 to java 8 based Go upgrade

### DIFF
--- a/installation/troubleshoot_installer.md
+++ b/installation/troubleshoot_installer.md
@@ -6,6 +6,7 @@ This page is mainly for newer users of GoCD, to help with troubleshooting issues
 - [Command not found (git, svn, mvn, ant or others)](#path_issues)
 - [Agent is not being assigned or "Nothing gets built"](#agent_assignment)
 - [Mac OS X - Message related to Java 1.7](#mac_java)
+- [Incompatible java version while upgrading to 17.x version](#upgrade-issues)
 
 <a name="agent_registration"></a>
 ### GoCD Agent not registering with the GoCD Server
@@ -257,3 +258,37 @@ Java 1.7+ executable.
 <style type="text/css">
   figure.small_image img { width: 50%; margin-left: 25%; }
 </style>
+
+<a name="upgrade-issues"></a>
+### Incompatible java version while upgrading to 17.x version
+
+Java 7 support is removed as part of 17.1 release.
+This implies an existing installation of Go will stop working after an upgrade
+if it is configured to run with Java 7.
+
+In such cases, one of the following error messages would be seen in the logs:
+
+```
+Unrecognized VM option "MaxMetaSpaceSize=256m"
+```
+or
+
+```
+UnSupported major.minor version 52.0
+```
+
+On Windows:
+
+This error will be logged, in `<GO_INSTALLATION_DIR>/go-server-wrapper.log` on server and
+`<GO_INSTALLATION_DIR>/go-agent-bootstrapper-wrapper.log` on agent, if startup failed due to incompatible version of java.
+
+Resolution: Update the environment variable `GO_SERVER_JAVA_HOME`, `GO_AGENT_JAVA_HOME`
+to the java 8 path and restart the Go server/agent.
+
+On Linux:
+
+This error will be logged, in `<GO_LOG_DIR>/go-server.out.log` on server and
+`<GO_LOG_DIR>/go-agent-bootstrapper.log` on agent, if startup failed due to incompatible version of java.
+
+Resolution: Update the environment variable JAVA_HOME set in `/etc/default/go-server`, `/etc/default/go-agent`
+to java 8 path, and restart the Go server/agent.

--- a/installation/troubleshoot_installer.md
+++ b/installation/troubleshoot_installer.md
@@ -6,7 +6,8 @@ This page is mainly for newer users of GoCD, to help with troubleshooting issues
 - [Command not found (git, svn, mvn, ant or others)](#path_issues)
 - [Agent is not being assigned or "Nothing gets built"](#agent_assignment)
 - [Mac OS X - Message related to Java 1.7](#mac_java)
-- [Incompatible java version while upgrading to 17.x version](#upgrade-issues)
+- [Unrecognized VM option "MaxMetaSpaceSize"](#upgrade-issues)
+- [Unsupported major.minor version 52.0](#upgrade-issues)
 
 <a name="agent_registration"></a>
 ### GoCD Agent not registering with the GoCD Server
@@ -274,21 +275,21 @@ Unrecognized VM option "MaxMetaSpaceSize=256m"
 or
 
 ```
-UnSupported major.minor version 52.0
+Unsupported major.minor version 52.0
 ```
 
 On Windows:
 
 This error will be logged, in `<GO_INSTALLATION_DIR>/go-server-wrapper.log` on server and
-`<GO_INSTALLATION_DIR>/go-agent-bootstrapper-wrapper.log` on agent, if startup failed due to incompatible version of java.
+`<GO_INSTALLATION_DIR>/go-agent-bootstrapper-wrapper.log` on agent, if startup failed due to incompatible version of Java.
 
 Resolution: Update the environment variable `GO_SERVER_JAVA_HOME`, `GO_AGENT_JAVA_HOME`
-to the java 8 path and restart the Go server/agent.
+to the Java 8 path and restart the Go server/agent.
 
 On Linux:
 
 This error will be logged, in `<GO_LOG_DIR>/go-server.out.log` on server and
-`<GO_LOG_DIR>/go-agent-bootstrapper.log` on agent, if startup failed due to incompatible version of java.
+`<GO_LOG_DIR>/go-agent-bootstrapper.log` on agent, if startup failed due to incompatible version of Java.
 
 Resolution: Update the environment variable JAVA_HOME set in `/etc/default/go-server`, `/etc/default/go-agent`
-to java 8 path, and restart the Go server/agent.
+to Java 8 path, and restart the Go server/agent.


### PR DESCRIPTION
When user upgrade from a Go Installation using java 7 to 17.1 or higher version the upgrade will be successful, but the start up would fail since the JAVA_HOME will still be pointed to java 7. So this guide can help is user setting up the JAVA_HOME properly in both linux and windows