### PR TITLE
Added explicit password flags for final keystore generation

### DIFF
--- a/installation/ssl_tls/custom_server_certificate.md
+++ b/installation/ssl_tls/custom_server_certificate.md
@@ -24,7 +24,7 @@ Assuming that you have the certificate key (`example.com.key`) and X509 certific
   **Note:** The destination keystore password must be set to `serverKeystorepa55w0rd`
 
   ```bash
-  $ keytool -importkeystore -srckeystore example.com.crt.pkcs12 -srcstoretype PKCS12 -destkeystore keystore -srcalias 1 -destalias cruise
+  $ keytool -importkeystore -srckeystore example.com.crt.pkcs12 -srcstoretype PKCS12 -destkeystore keystore -srcalias 1 -destalias cruise -deststorepass 'serverKeystorepa55w0rd' -destkeypass 'serverKeystorepa55w0rd'
   ```
 
 4. Replace GoCD server's keystore with the one from above


### PR DESCRIPTION
Added commands to force keystore and key passwords to match on final keystore regardless of previous passwords. Maybe 1 is unnecessary here?