### PR TITLE
Allow overriding meta keywords and description

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,7 @@
+{% extends template.self %}
+
+{% block description %}{{ page.description | default("GoCD is an open source continuous delivery server that helps organizations increase productivity and deliver high quality software through automation.") }}{% endblock %}
+
+{% block head %}
+<meta content="{{ page.keywords|default("continuous delivery, software, continuous integration, open source, blog, software development, tools, automation, deployment pipelines, devops, techniques") }}" name="keywords" />
+{% endblock %}

--- a/book.json
+++ b/book.json
@@ -1,6 +1,6 @@
 {
-    "title": "Go User Documentation",
-    "description": "Help documentation for Go.",
+    "title": "GoCD User Documentation",
+    "description": "Help documentation for GoCD.",
     "links": {
         "sidebar": {
             "Home": "https://www.gocd.org",


### PR DESCRIPTION
With this, you can add a header such as this (below) to a markdown file and it'll change the keywords and description metadata in the page head:

```
---
description: Page description goes here
keywords: some, key, words, here
---
```

If not provided, there's a default (same as www.gocd.org).

/cc @nyuday 