### PR TITLE
Update Pipelines as Code and Config Reference Docs for 17.8.0

### DIFF
--- a/advanced_usage/pipelines_as_code.md
+++ b/advanced_usage/pipelines_as_code.md
@@ -45,7 +45,7 @@ The setup needed to allow this is:
 
       ```xml
       <config-repos>
-        <config-repo plugin="json.config.plugin">
+        <config-repo plugin="json.config.plugin" id="gocd-demo-config-repo-json">
           <git url="https://github.com/arvindsv/gocd-demo-config-repo-json.git" />
         </config-repo>
       </config-repos>
@@ -74,7 +74,7 @@ Tomasz [announced](https://groups.google.com/forum/#!topic/go-cd/bAFYdWOQLEs/dis
 
       ```xml
       <config-repos>
-        <config-repo plugin="yaml.config.plugin">
+        <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
           <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
         </config-repo>
       </config-repos>

--- a/advanced_usage/pipelines_as_code.md
+++ b/advanced_usage/pipelines_as_code.md
@@ -45,7 +45,7 @@ The setup needed to allow this is:
 
       ```xml
       <config-repos>
-        <config-repo plugin="json.config.plugin" id="gocd-demo-config-repo-json">
+        <config-repo pluginId="json.config.plugin" id="gocd-demo-config-repo-json">
           <git url="https://github.com/arvindsv/gocd-demo-config-repo-json.git" />
         </config-repo>
       </config-repos>
@@ -74,7 +74,7 @@ Tomasz [announced](https://groups.google.com/forum/#!topic/go-cd/bAFYdWOQLEs/dis
 
       ```xml
       <config-repos>
-        <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
+        <config-repo pluginId="yaml.config.plugin" id="gocd-yaml-config-example">
           <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
         </config-repo>
       </config-repos>

--- a/configuration/configuration_reference.md
+++ b/configuration/configuration_reference.md
@@ -806,10 +806,10 @@ The `<config-repos>` element is a container of many `<config-repo>`.
 <cruise>
   ...
   <config-repos>
-    <config-repo plugin="json.config.plugin">
+    <config-repo plugin="json.config.plugin" id="gocd-json-config-example">
       <git url="https://github.com/tomzo/gocd-json-config-example.git" />
     </config-repo>
-    <config-repo plugin="yaml.config.plugin">
+    <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
       <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
       <configuration>
         <property>
@@ -833,6 +833,7 @@ The `<config-repo>` element specifies a single configuration repository. It must
 | Attribute | Required | Description |
 |-----------|----------|-------------|
 | plugin | Yes | The ID of configuration repository plugin. E.g. `json.config.plugin`. |
+| id | Yes | The ID of the configuration repository. ID must be a unique alphanumeric string. It can also contain `-`,`_`,`.`. |
 
 ### Example
 
@@ -840,7 +841,7 @@ The `<config-repo>` element specifies a single configuration repository. It must
 <cruise>
     ...
     <config-repos>
-      <config-repo plugin="yaml.config.plugin">
+      <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
         <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
         <configuration>
           <property>

--- a/configuration/configuration_reference.md
+++ b/configuration/configuration_reference.md
@@ -806,10 +806,10 @@ The `<config-repos>` element is a container of many `<config-repo>`.
 <cruise>
   ...
   <config-repos>
-    <config-repo plugin="json.config.plugin" id="gocd-json-config-example">
+    <config-repo pluginId="json.config.plugin" id="gocd-json-config-example">
       <git url="https://github.com/tomzo/gocd-json-config-example.git" />
     </config-repo>
-    <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
+    <config-repo pluginId="yaml.config.plugin" id="gocd-yaml-config-example">
       <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
       <configuration>
         <property>
@@ -832,7 +832,7 @@ The `<config-repo>` element specifies a single configuration repository. It must
 
 | Attribute | Required | Description |
 |-----------|----------|-------------|
-| plugin | Yes | The ID of configuration repository plugin. E.g. `json.config.plugin`. |
+| pluginId | Yes | The ID of configuration repository plugin. E.g. `json.config.plugin`. |
 | id | Yes | The ID of the configuration repository. ID must be a unique alphanumeric string. It can also contain `-`,`_`,`.`. |
 
 ### Example
@@ -841,7 +841,7 @@ The `<config-repo>` element specifies a single configuration repository. It must
 <cruise>
     ...
     <config-repos>
-      <config-repo plugin="yaml.config.plugin" id="gocd-yaml-config-example">
+      <config-repo pluginId="yaml.config.plugin" id="gocd-yaml-config-example">
         <git url="https://github.com/tomzo/gocd-yaml-config-example.git" />
         <configuration>
           <property>


### PR DESCRIPTION
`id` is now a required component of `config-repo`. Fixes #110.