### PR TITLE
"it's" => "its"

### DIFF
--- a/introduction/concepts_in_go.md
+++ b/introduction/concepts_in_go.md
@@ -1,5 +1,5 @@
 ---
-description: Introduction to GoCD, it's underlying concepts, and get a good understanding of continuous delivery and continuous integration.
+description: Introduction to GoCD, its underlying concepts, and get a good understanding of continuous delivery and continuous integration.
 keywords: introduction gocd, continuous delivery, continuous integration, martin fowler, gocd getting started, build pipelines, value stream map, build artifacts, fan in
 ---
 


### PR DESCRIPTION
Apologies for the disappointing first contribution, hopefully will have something more substantial in the future :wink:

["It's" is always short for "it is"](https://en.oxforddictionaries.com/usage/its-or-it-s), but since we're talking about concepts which comprise GoCD we're implying possession.