### PR TITLE
Fixes invalid XML when defining users

### DIFF
--- a/configuration/dev_authorization.md
+++ b/configuration/dev_authorization.md
@@ -41,12 +41,16 @@ For power users, here's how you would configure roles via "Config XML":
 
       <roles>
         <role name="qa">
-          <user>dyang</user>
-          <user>pavan</user>
+          <users>
+            <user>dyang</user>
+            <user>pavan</user>
+          </users>
         </role>
         <role name="go_admin">
-          <user>jhumble</user>
-          <user>qiao</user>
+          <users> 
+            <user>jhumble</user>
+            <user>qiao</user>
+          </users>
         </role>
       </roles>
 


### PR DESCRIPTION
The XML fragment that defined users is invalid as it does not start with an opening users tag.