### PR TITLE
 added overide startup section for linux agent 

### DIFF
--- a/installation/configure-agent-proxy.md
+++ b/installation/configure-agent-proxy.md
@@ -45,7 +45,7 @@ AGENT_BOOTSTRAPPER_JVM_ARGS="${PROXY_SETTINGS}"
 ## Configuring an agent on Windows
 
 
-Follow the [instructions](../install/agent/windows.html#overriding-default-startup-arguments-and-environment) to add a new property for GoCD agents setup on windows, such as:
+Follow the [instructions](../installation/install/agent/windows.html#overriding-default-startup-arguments-and-environment) to add a new property for GoCD agents setup on windows, such as:
 
 ```
 wrapper.java.additional.17="-Dhttps.proxyHost=proxy.example.com -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts='localhost|*.department.acme.com'"

--- a/installation/install/agent/linux.md
+++ b/installation/install/agent/linux.md
@@ -73,4 +73,14 @@ The GoCD agent installs its files in the following locations on your filesystem:
 /etc/default/go-agent  #contains all the environment variables with default values. These variable values can be changed as per requirement
 ```
 
+## Overriding default startup arguments and environment
+
+Users can override default startup arguments for a GoCD agent in a Linux machine by editing the file etc/default/go-agent.
+
+For e.g To enable Websocket communication between the server and agent, user can add the following GoCD agent system property
+
+```bash
+ export GO_AGENT_SYSTEM_PROPERTIES="$GO_AGENT_SYSTEM_PROPERTIES -Dgo.agent.websocket.enabled=true"
+ ```
+
 !INCLUDE "_register_with_server.md"


### PR DESCRIPTION
following two changes

1. Added Overriding default startup arguments and environment for linux agent
2. Corrected broken link in configure-agent-proxy.md