### PR TITLE
Do not say that Tests support xUnit xml

### DIFF
--- a/configuration/dev_upload_test_report.md
+++ b/configuration/dev_upload_test_report.md
@@ -5,7 +5,7 @@ keywords: GoCD configuration, publishing artifacts, reports, GoCD pipeline, job 
 
 # Publishing artifacts
 
-When executing a job on an agent there are often artifacts created that we need to keep around. For example, JUnit creates xml reports that GoCD is able to parse in order to help you [understand why the build is broken](../faq/dev_understand_why_build_broken.md). You can use GoCD with any XUnit style xml reports. Or you might create a flash video of your UI tests that we want displayed in GoCD. You can upload any html file from your build and view it in GoCD.
+When executing a job on an agent there are often artifacts created that we need to keep around. For example, JUnit creates xml reports that GoCD is able to parse in order to help you [understand why the build is broken](../faq/dev_understand_why_build_broken.md). You can use GoCD with any JUnit style xml reports. Or you might create a flash video of your UI tests that we want displayed in GoCD. You can upload any html file from your build and view it in GoCD.
 
 To publish artifacts you add a an [< artifact >](configuration_reference.md#artifact) to the job configuration. More information can be found on the [Managing artifacts and reports](managing_artifacts_and_reports.md) page.
 


### PR DESCRIPTION
Discussion on (gitter yesterday](https://gitter.im/gocd/gocd?at=5a505ef2290a1f456155708d)
concluded with 

@ketan 

> The only format GoCD understands is junit. And some Versi n of nunit. 

As such  the docs should not say:

> You can use GoCD with any XUnit style xml reports

As the [xUnit style](https://xunit.github.io/docs/format-xml-v2.html), and [JUnit style](https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_9.5.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html)
are very different.

I assume the versions of nUnit which work are ones that are "JUnit style".

This PR is literally a single letter change.