### PR TITLE
Added path to `cruise-config.xml` file

### DIFF
--- a/installation/install/server/_install_server_footer.md
+++ b/installation/install/server/_install_server_footer.md
@@ -2,7 +2,7 @@
 
 You can replicate a GoCD server with all the pipeline, stage, job, tasks and materials definitions/configuration intact.
 
-To do this, the administrator should copy ```cruise-config.xml``` from the config directory to the new server and clear
+To do this, the administrator should copy ```/etc/go/cruise-config.xml``` from the config directory (`/etc/go`) to the new server and clear
 `serverId` attribute of `server` tag.
 
 > **Note:** Copying just the ```cruise-config.xml``` file will not migrate the historical pipeline data and


### PR DESCRIPTION
Otherwise, it is not clear, where to look for `cruise-config.xml`. 

Unfortunately, this can be confusing, cause if you're observing `/etc/go` directory with a regular user, you don't have permissions to see it.