### PR TITLE
Fixed undefined title in search results

### DIFF
--- a/content/faq/dev_use_current_revision_in_build.md
+++ b/content/faq/dev_use_current_revision_in_build.md
@@ -1,6 +1,7 @@
 ---
 description: Using environment variables in GoCD
-keywords: environment variable, GoCD configuration, GoCD tasks, custom command, shell-script, ruby script,
+keywords: environment variable, GoCD configuration, GoCD tasks, custom command, shell-script, ruby script, 
+title: Use Environment Variables in GoCD
 aliases:
     - /faq/environment_variables.html
 ---

--- a/content/installation/troubleshooting.md
+++ b/content/installation/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 description: Troubleshooting GoCD server and agent installation errors.
 keywords: gocd troubleshooting, installation errors gocd, agent not registering, ssl error
+title: GoCD Troubleshooting issues
 aliases:
     - /installation/troubleshoot_installer.html
 ---

--- a/rakelib/build.rake
+++ b/rakelib/build.rake
@@ -1,4 +1,5 @@
 require 'rake/clean'
+require 'yaml'
 
 CLEAN.include('build')
 CLEAN.include('resources')
@@ -13,6 +14,30 @@ task :run_hugo do
   sh('yarn run hugo')
 end
 
+desc 'Check for title property on every md file'
+task :check_for_title do
+  missing_title = []
+  Dir['content/**/*.md'].select {|file|
+    if file.exclude? 'index.md'
+      begin
+        thing = YAML.load_file(file)
+        title = thing['title']
+        unless title
+          missing_title.push(file)
+        end
+      rescue
+        missing_title.push(file)
+      end
+    end
+  }
+  if missing_title.length > 0
+    raise 'Title is mandatory for search functionality' + "\n" + missing_title.join("\n")
+  else
+    puts 'Success!!!'
+  end
+end
+
 desc "build the documentation"
-task :compile => [:clean, :init, :run_hugo]
+task :compile => [:clean, :init, :check_for_title, :run_hugo]
 task :build => [:compile, "static_checks:all"]
+


### PR DESCRIPTION
Bug
certain search results had undefined as the title

Reason:
missing title property

Fix:
Added task to check if title property is present on all md files excluding index.md