### PR TITLE
Improved search functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@ const S = require("string");
 const Markdown = require("markdown-it");
 const He = require('he');
 const lunr = require('lunr');
+lunr.tokenizer.separator = /[^\.a-zA-Z0-9_-]+/; // token separator is now all chars except alphanumeric, underscore, hypen and dot - default was space and hypen
 
 const CONTENT_PATH_PREFIX = "content";
 const md = new Markdown();

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ const GrayMatter = require('gray-matter');
 const S = require("string");
 const Markdown = require("markdown-it");
 const He = require('he');
-const lunr = require('lunr')
+const lunr = require('lunr');
 
 const CONTENT_PATH_PREFIX = "content";
 const md = new Markdown();
@@ -74,10 +74,15 @@ module.exports = function (grunt) {
             }
 
             // Build Lunr index for this page
+            const keywords = (frontMatter.keywords === undefined)
+                ? undefined
+                : frontMatter.keywords
+                    .split(',')
+                    .map((keyword) => keyword.trim());
             pageIndex = {
                 title: frontMatter.title,
                 description: frontMatter.description,
-                keywords: frontMatter.keywords,
+                keywords: keywords,
                 href: href,
                 content: He.decode(sanitizeInput(md.render(sanitizeInput(content.content)))
                     .replace(/[(\n)]+/ig, ' ').trim())

--- a/content/advanced_usage/config_repo.md
+++ b/content/advanced_usage/config_repo.md
@@ -1,6 +1,6 @@
 ---
 description: GoCD's configuration is version controlled in a local git repository. It allows auditing of all changes made to the configuration.
-keywords: GoCD configuration repository, garbage collection, config repo,
+keywords: GoCD configuration repository, garbage collection, config repo, config-repo
 title: Config Repository
 ---
 

--- a/content/configuration/elastic_agents.md
+++ b/content/configuration/elastic_agents.md
@@ -1,6 +1,6 @@
 ---
 description: Managing elastic agents with GoCD
-keywords: GoCD configuration, elastic agents, docker, ecs, cloud
+keywords: GoCD configuration, elastic agents, docker, ecs, cloud, dynamic agents, elastic-agents, dynamic-agents, elastic
 title: Elastic Agents
 ---
 

--- a/static/javascripts/search/search.js
+++ b/static/javascripts/search/search.js
@@ -47,7 +47,7 @@ function initUI() {
 
     $("#search").keyup(function () {
 
-        const query = $(this).val();
+        const query = $(this).val().trim();
 
         if (query.length < 2) {
             searchUI(SearchStatus.init);
@@ -69,6 +69,7 @@ function search(query) {
 }
 
 function doSearch(searchQuery) {
+    searchQuery = searchQuery.replace(/[ ]/, '\\ ');
     return lunrIndex.search(searchQuery).map(function (result) {
         return pagesIndex.filter(function (page) {
             return page.href === result.ref;

--- a/static/javascripts/search/search.js
+++ b/static/javascripts/search/search.js
@@ -62,14 +62,15 @@ function initUI() {
 function search(query) {
     let searchResults = doSearch(query);
     if (searchResults.length === 0) {
-        let partialMatchQuery = query + "*";
+        let partialMatchQuery = `*${query}*`;
         return doSearch(partialMatchQuery);
     }
     return searchResults;
 }
 
 function doSearch(searchQuery) {
-    searchQuery = searchQuery.replace(/[ ]/, '\\ ');
+    // escaping chars: hyphen, dot, underscore and space in the search query
+    searchQuery = searchQuery.replace(/[-\._ ]/g, '\\$&');
     return lunrIndex.search(searchQuery).map(function (result) {
         return pagesIndex.filter(function (page) {
             return page.href === result.ref;


### PR DESCRIPTION
By default, lunr treats space as a token separator. So given a search string with
space, each word will be treated as a separate token i.e. separate keywords to be
searched.

 - passed in the keywords as an array of strings during lunr index creation
 - escaped the spaces, hyphen, dot and underscore in the search string

More info: https://lunrjs.com/guides/searching.html