### PR TITLE
Add client_max_body_size to nginx conf

### DIFF
--- a/content/installation/configure-reverse-proxy.md
+++ b/content/installation/configure-reverse-proxy.md
@@ -112,6 +112,11 @@ server {
     proxy_set_header 	      Upgrade $http_upgrade;
     proxy_set_header 	      Connection $connection_upgrade;
     proxy_pass              http://localhost:8153/;
+    
+    # To be able to upload artifacts larger than default size of 1mb, ensure that you set this up to a large value.
+    # setting to `0` will disable checking for body size.
+    # See https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    client_max_body_size  10000m;
   }
 }
 ```

--- a/content/installation/configure-reverse-proxy.md
+++ b/content/installation/configure-reverse-proxy.md
@@ -79,10 +79,6 @@ NameVirtualHost nnn.nnn.nnn.nnn:80
 ## GoCD with NGINX
 
 ```nginx
-http {
-  client_max_body_size  10000m;
-}
-
 server {
   # Redirect any http requests to https
   listen         80;

--- a/content/installation/configure-reverse-proxy.md
+++ b/content/installation/configure-reverse-proxy.md
@@ -78,19 +78,11 @@ NameVirtualHost nnn.nnn.nnn.nnn:80
 
 ## GoCD with NGINX
 
-To `/etc/nginx/nginx.conf` add the `client_max_body_size` to the `http` section so that agents can upload huge artifacts:
-
 ```nginx
 http {
-  ...
   client_max_body_size  10000m;
-  ...
 }
-```
 
-The configuration of the site in `/etc/nginx/sites-enabled`
-
-```nginx
 server {
   # Redirect any http requests to https
   listen         80;

--- a/content/installation/configure-reverse-proxy.md
+++ b/content/installation/configure-reverse-proxy.md
@@ -78,6 +78,18 @@ NameVirtualHost nnn.nnn.nnn.nnn:80
 
 ## GoCD with NGINX
 
+To `/etc/nginx/nginx.conf` add the `client_max_body_size` to the `http` section so that agents can upload huge artifacts:
+
+```nginx
+http {
+  ...
+  client_max_body_size  10000m;
+  ...
+}
+```
+
+The configuration of the site in `/etc/nginx/sites-enabled`
+
 ```nginx
 server {
   # Redirect any http requests to https


### PR DESCRIPTION
Prevented large artifacts to be uploaded through nginx reverse proxy.