### PR TITLE
Remove links to developer docs

### DIFF
--- a/content/extension_points/plugin_user_guide.md
+++ b/content/extension_points/plugin_user_guide.md
@@ -8,7 +8,7 @@ title: Plugin User Guide
 
 ## Introduction
 
-Plugins allow users to extend the functionality of GoCD. Each plugin is assigned an identifier which is determined by the **id** attribute provided in plugin metadata file packaged along with the plugin jar. If the [metadata](https://developer.gocd.org/current/writing_go_plugins/go_plugins_basics.html#plugin-metadata) file is not packaged, plugin jar file name will be taken as plugin id. Plugins are classified into two categories - Bundled and External. During startup, GoCD server would try to load all the plugins. On successful load, the plugin will be converted into an OSGi bundle and extracted into `<server installation directory>/plugins_work` directory. **Plugins** tab, under GoCD server Administration, would list all the loaded plugins.
+Plugins allow users to extend the functionality of GoCD. Each plugin is assigned an identifier which is determined by the **id** attribute provided in plugin metadata file packaged along with the plugin jar. If the metadata file is not packaged, plugin jar file name will be taken as plugin id. Plugins are classified into two categories - Bundled and External. During startup, GoCD server would try to load all the plugins. On successful load, the plugin will be converted into an OSGi bundle and extracted into `<server installation directory>/plugins_work` directory. **Plugins** tab, under GoCD server Administration, would list all the loaded plugins.
 
 ## Bundled versus External
 

--- a/content/extension_points/scm_extension.md
+++ b/content/extension_points/scm_extension.md
@@ -103,6 +103,6 @@ VCS/SCM plugin will by default checkout code into `destination` directory on Age
 
 ## References:
 
-* [Developer docs](https://developer.gocd.org/current/writing_go_plugins/scm_material/json_message_based_scm_material_extension.html)
+* [Developer docs](https://plugin-api.gocd.org/current/scm/)
 * [SCM Plugins](https://www.gocd.org/community/plugins.html#scm-plugins-count)
 * [Github issue](https://github.com/gocd/gocd/issues/818)

--- a/content/extension_points/task_extension.md
+++ b/content/extension_points/task_extension.md
@@ -14,7 +14,7 @@ GoCD supports configuring a few kinds of tasks (Nant, Ant and Rake), directly, f
 
 A task plugin allows you to extend this so that you can have other tasks available here. The plugin also allows you to control the UI, as well as the data stored for this task.
 
-For instance, you can find the source of a sample Curl plugin, [at this location](https://developer.gocd.org/current/writing_go_plugins/go_plugins_basics.html#building-a-plugin). Assuming you have the plugin installed, you'll see that the dropdown in the job configuration UI has changed to look like this:
+For instance, you can find the source of a sample Curl plugin, [at this location](https://github.com/gocd/sample-plugins/tree/master/curl-plugin). Assuming you have the plugin installed, you'll see that the dropdown in the job configuration UI has changed to look like this:
 
 ![](../images/2_With_Curl.png)
 
@@ -69,4 +69,4 @@ Dload  Upload   Total   Spent    Left  Speed
 0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
 100   259  100   259    0     0    122      0  0:00:02  0:00:02 --:--:--   122
 ```
-You can write a task plugin in GoCD using [JSON API - Message based](https://developer.gocd.org/current/writing_go_plugins/task/json_message_based_task_extension.html)
+You can write a task plugin in GoCD using [JSON API - Message based](https://plugin-api.gocd.org/current/tasks/)


### PR DESCRIPTION
Point to plugin API docs instead.