### PR TITLE
Add auto register file location

### DIFF
--- a/content/advanced_usage/agent_auto_register.md
+++ b/content/advanced_usage/agent_auto_register.md
@@ -18,7 +18,7 @@ As a GoCD administrator, you can auto approve remote agents by using a shared ke
 </cruise>
 ```
 
-- On the remote GoCD Agent machine, create a file named `<agent_installation_directory>/config/autoregister.properties`.
+- On the remote GoCD Agent machine, create a file named `<agent_installation_directory>/config/autoregister.properties`. In a native agent installation this file is usually located on `/var/lib/go-agent/config/` directory. The `config/` folder might not exist, in this case you should create it by yourself.
 
     This file supports the following properties
 


### PR DESCRIPTION
In the latest versions file autoregister.properties has been changed from /usr/share/go-agent/config/ to /var/lib/go-agent/config/. I think it is important to know where to find it.