### PR TITLE
Updating documentation with new common issue.

### DIFF
--- a/content/faq/fixing_common_issues.md
+++ b/content/faq/fixing_common_issues.md
@@ -235,6 +235,19 @@ The AJAX API request has a timeout set to 5000 milliseconds, if the server does 
 
 Resolution: If this is happening, consider increase the timeout period by specifying the [go.spa.timeout](../advanced_usage/other_config_options.html#go-spa-timeout)
 
+<a name="https-port-not-started"></a>
+### Application not listening to port 8154 (HTTPS) 
+
+The server will no longer generate any self signed SSL certificates or listen to 8154 (HTTPS) port by default.
+As mentioned on GitHub page <a href="https://github.com/gocd/gocd/pull/7669#issuecomment-580290432">(CLICK FOR MORE INFO)</a>:
+
+    To keep backward compatibility and minimize disruption:
+    
+    - New versions of GoCD (>= 20.2) will not bring up TLS port 8154. There will be no way for such users to configure built-in TLS. A reverse proxy will need to be the one terminating TLS if needed.
+    - Users upgrading to GoCD (20.2-20.4) will notice that the server does not bring up TLS on port 8154, but emits a warning indicating how they can turn it on, and go back to how it was earlier. The warning message will include a timeline when the toggle will go away, along with instructions on how to set it up correctly using a reverse proxy.
+    - Version 20.5 of GoCD server will no longer contain any functionality to configure TLS. At this point, users will be expected to terminate SSL elsewhere.
+
+
 <a name="ports-in-use"></a>
 ### Port 8153 (HTTP) or 8154 (HTTPS) could not be opened
 


### PR DESCRIPTION
There isn't a single line in documentation explaining that application will no longer automatically start port 8154 (HTTPS). New users (like me) can think that application was unable to start listening on port 8154. After searching whole day I found answer "hidden" on GitHub, but I think this will be more helpfull.