### PR TITLE
[Latest release] Add quarantine instructions to Mac OS X docs

### DIFF
--- a/content/installation/install/agent/osx.md
+++ b/content/installation/install/agent/osx.md
@@ -4,8 +4,19 @@ title: Installing GoCD server on Mac OS X
 
 # Installing GoCD agent on Mac OS X
 
-- Download the Mac OSX installer for GoCD agent from [downloads page](https://www.gocd.org/download/)
-- Unzip the installer in a folder of your choice. It creates a subfolder with the name ```go-agent-${version}```
+- Download the Mac OS X installer for GoCD Agent from [downloads page](https://www.gocd.org/download/).
+- Unzip the installer in a directory of your choice. It creates a sub-directory with the name ```go-agent-${version}```.
+- Mark the directory as not quarantined by Mac OS X so that it allows the GoCD Agent to be started:
+
+    ```
+    # Assuming, for example, that the directory is "go-agent-20.5.0".
+    $ cd go-agent-20.5.0
+    $ xattr -d -r com.apple.quarantine .
+    xattr: [Errno 13] Permission denied: './jre/Contents/Home/lib/server/classes.jsa'
+    xattr: [Errno 13] Permission denied: './jre/Contents/Home/legal/jdk.dynalink/dynalink.md'
+    ... # These "Permission denied" warnings can be ignored.
+    ```
+
 
 ## Managing the GoCD agent process
 

--- a/content/installation/install/server/osx.md
+++ b/content/installation/install/server/osx.md
@@ -4,8 +4,18 @@ title: Installing GoCD server on Mac OS X
 
 # Installing GoCD server on Mac OS X
 
-- Download the Mac OSX installer for GoCD server from [downloads page](https://www.gocd.org/download/)
-- Unzip the installer in a folder of your choice. It creates a subfolder with the name ```go-server-${version}```
+- Download the Mac OS X installer for GoCD Server from [downloads page](https://www.gocd.org/download/).
+- Unzip the installer in a directory of your choice. It creates a sub-directory with the name ```go-server-${version}```.
+- Mark the directory as not quarantined by Mac OS X so that it allows the GoCD Server to be started:
+
+    ```
+    # Assuming, for example, that the directory is "go-server-20.5.0".
+    $ cd go-server-20.5.0
+    $ xattr -d -r com.apple.quarantine .
+    xattr: [Errno 13] Permission denied: './jre/Contents/Home/lib/server/classes.jsa'
+    xattr: [Errno 13] Permission denied: './jre/Contents/Home/legal/jdk.dynalink/dynalink.md'
+    ... # These "Permission denied" warnings can be ignored.
+    ```
 
 ## Managing the GoCD server process
 


### PR DESCRIPTION
For https://github.com/gocd/gocd/issues/8354.

<img width="867" alt="agent" src="https://user-images.githubusercontent.com/172235/87913865-ad877780-ca67-11ea-84e4-83300365c9ce.png">


<hr>

<img width="883" alt="server" src="https://user-images.githubusercontent.com/172235/87913869-afe9d180-ca67-11ea-9b71-f4c0c58b4ce7.png">
