### PR TITLE
Update Helm install guide to use GoCD Helm repo

### DIFF
--- a/content/gocd_on_kubernetes/helm_install.md
+++ b/content/gocd_on_kubernetes/helm_install.md
@@ -11,13 +11,22 @@ aliases:
 
 Helm is a package manager for Kubernetes. Kubernetes packages are called charts. Charts are curated applications for Kubernetes.  
 
-First verify your Helm version using command `helm version`.
+First verify your Helm version using command `helm version`, then install the official GoCD Helm chart as follows:
 
-For Helm version 3 and bove, install the official GoCD Helm chart with this command:
+1. Add the GoCD helm chart repository: 
+
+```bash
+helm repo add gocd https://gocd.github.io/helm-chart
+helm repo update
+```
+
+2. Run the install command:
+
+For Helm v3:
 
 ```bash
 kubectl create ns gocd
-helm install gocd stable/gocd --namespace gocd
+helm install gocd gocd/gocd --namespace gocd
 ```
 
 If you're using an older version of Helm, then use this command:


### PR DESCRIPTION
The `stable/gocd` chart is now deprecated (https://github.com/helm/charts/tree/master/stable/gocd). This PR updates the docs to point to [GoCD's new Helm repo](https://github.com/gocd/helm-chart).